### PR TITLE
add escapeshellarg to fix CVE-2019-13024 line #212

### DIFF
--- a/www/include/configuration/configGenerate/xml/generateFiles.php
+++ b/www/include/configuration/configGenerate/xml/generateFiles.php
@@ -209,7 +209,7 @@ function printDebug($xml, $tabs)
 
     foreach ($tab_server as $host) {
         $stdout = shell_exec(
-            $nagios_bin["nagios_bin"] . " -v " . $nagiosCFGPath . $host["id"] . "/centengine.DEBUG 2>&1"
+            escapeshellarg($nagios_bin["nagios_bin"]) . " -v " . $nagiosCFGPath . escapeshellarg($host["id"]) . "/centengine.DEBUG 2>&1"
         );
         $stdout = htmlspecialchars($stdout, ENT_QUOTES, "UTF-8");
         $msg_debug[$host['id']] = str_replace("\n", "<br />", $stdout);


### PR DESCRIPTION
I just added escapeshellarg to filter nagion_bin variable after being called from the database to fix CVE-2019-13024.